### PR TITLE
Fix handling of '*' origin and add support of file:// protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ phone.addListener('testMessage', function (content) {
 phone.initialize();
 ```
 
+## Changelog
+
+#### 1.2.0
+ - Added support of `file://` protocol (both ParentEndpoint and IframeEndpoint need to be upgraded to >= v1.2.0)
+ - Origin check removed from IframeEndpoint (it didn't provide any security)
+
+
 ## Licensing
 
 iframe-phone is Copyright 2012 (c) by the Concord Consortium and is distributed under [MIT](http://www.opensource.org/licenses/MIT) license.

--- a/lib/iframe-endpoint.js
+++ b/lib/iframe-endpoint.js
@@ -3,21 +3,20 @@ var HELLO_INTERVAL_LENGTH = 200;
 var HELLO_TIMEOUT_LENGTH = 60000;
 
 function IFrameEndpoint() {
-  var parentOrigin;
   var listeners = {};
   var isInitialized = false;
   var connected = false;
   var postMessageQueue = [];
   var helloInterval;
 
-  function postToTarget(message, target) {
+  function postToParent(message) {
     // See http://dev.opera.com/articles/view/window-postmessage-messagechannel/#crossdoc
     //     https://github.com/Modernizr/Modernizr/issues/388
     //     http://jsfiddle.net/ryanseddon/uZTgD/2/
     if (structuredClone.supported()) {
-      window.parent.postMessage(message, target);
+      window.parent.postMessage(message, '*');
     } else {
-      window.parent.postMessage(JSON.stringify(message), target);
+      window.parent.postMessage(JSON.stringify(message), '*');
     }
   }
 
@@ -34,19 +33,16 @@ function IFrameEndpoint() {
       };
     }
     if (connected) {
-      postToTarget(message, parentOrigin);
+      postToParent(message);
     } else {
       postMessageQueue.push(message);
     }
   }
 
-  // Only the initial 'hello' message goes permissively to a '*' target (because due to cross origin
-  // restrictions we can't find out our parent's origin until they voluntarily send us a message
-  // with it.)
   function postHello() {
-    postToTarget({
+    postToParent({
       type: 'hello'
-    }, '*');
+    });
   }
 
   function addListener(type, fn) {
@@ -64,15 +60,10 @@ function IFrameEndpoint() {
   function messageListener(message) {
     // Anyone can send us a message. Only pay attention to messages from parent.
     if (message.source !== window.parent) return;
-
     var messageData = message.data;
-
     if (typeof messageData === 'string') messageData = JSON.parse(messageData);
 
-    // We don't know origin property of parent window until it tells us.
     if (!connected && messageData.type === 'hello') {
-      // This is the return handshake from the embedding window.
-      parentOrigin = messageData.origin;
       connected = true;
       stopPostingHello();
       while (postMessageQueue.length > 0) {
@@ -80,9 +71,8 @@ function IFrameEndpoint() {
       }
     }
 
-    // Perhaps-redundantly insist on checking origin as well as source window of message.
-    if (parentOrigin === '*' || message.origin === parentOrigin) {
-      if (listeners[messageData.type]) listeners[messageData.type](messageData.content);
+    if (connected && listeners[messageData.type]) {
+      listeners[messageData.type](messageData.content);
     }
   }
 
@@ -107,7 +97,6 @@ function IFrameEndpoint() {
 
     // We kick off communication with the parent window by sending a "hello" message. Then we wait
     // for a handshake (another "hello" message) from the parent window.
-    postHello();
     startPostingHello();
     window.addEventListener('message', messageListener, false);
   }
@@ -118,6 +107,8 @@ function IFrameEndpoint() {
     }
     helloInterval = window.setInterval(postHello, HELLO_INTERVAL_LENGTH);
     window.setTimeout(stopPostingHello, HELLO_TIMEOUT_LENGTH);
+    // Post the first msg immediately.
+    postHello();
   }
 
   function stopPostingHello() {
@@ -127,12 +118,12 @@ function IFrameEndpoint() {
 
   // Public API.
   return {
-    initialize        : initialize,
-    getListenerNames  : getListenerNames,
-    addListener       : addListener,
+    initialize: initialize,
+    getListenerNames: getListenerNames,
+    addListener: addListener,
     removeAllListeners: removeAllListeners,
-    disconnect        : disconnect,
-    post              : post
+    disconnect: disconnect,
+    post: post
   };
 }
 

--- a/lib/iframe-endpoint.js
+++ b/lib/iframe-endpoint.js
@@ -45,8 +45,7 @@ function IFrameEndpoint() {
   // with it.)
   function postHello() {
     postToTarget({
-      type: 'hello',
-      origin: document.location.href.match(/(.*?\/\/.*?)\//)[1]
+      type: 'hello'
     }, '*');
   }
 
@@ -82,7 +81,7 @@ function IFrameEndpoint() {
       }
 
       // Perhaps-redundantly insist on checking origin as well as source window of message.
-      if (message.origin === parentOrigin) {
+      if (parentOrigin === '*' || message.origin === parentOrigin) {
         if (listeners[messageData.type]) listeners[messageData.type](messageData.content);
       }
    }

--- a/lib/iframe-endpoint.js
+++ b/lib/iframe-endpoint.js
@@ -62,35 +62,35 @@ function IFrameEndpoint() {
   }
 
   function messageListener(message) {
-      // Anyone can send us a message. Only pay attention to messages from parent.
-      if (message.source !== window.parent) return;
+    // Anyone can send us a message. Only pay attention to messages from parent.
+    if (message.source !== window.parent) return;
 
-      var messageData = message.data;
+    var messageData = message.data;
 
-      if (typeof messageData === 'string') messageData = JSON.parse(messageData);
+    if (typeof messageData === 'string') messageData = JSON.parse(messageData);
 
-      // We don't know origin property of parent window until it tells us.
-      if (!connected && messageData.type === 'hello') {
-        // This is the return handshake from the embedding window.
-        parentOrigin = messageData.origin;
-        connected = true;
-        stopPostingHello();
-        while(postMessageQueue.length > 0) {
-          post(postMessageQueue.shift());
-        }
+    // We don't know origin property of parent window until it tells us.
+    if (!connected && messageData.type === 'hello') {
+      // This is the return handshake from the embedding window.
+      parentOrigin = messageData.origin;
+      connected = true;
+      stopPostingHello();
+      while (postMessageQueue.length > 0) {
+        post(postMessageQueue.shift());
       }
+    }
 
-      // Perhaps-redundantly insist on checking origin as well as source window of message.
-      if (parentOrigin === '*' || message.origin === parentOrigin) {
-        if (listeners[messageData.type]) listeners[messageData.type](messageData.content);
-      }
-   }
+    // Perhaps-redundantly insist on checking origin as well as source window of message.
+    if (parentOrigin === '*' || message.origin === parentOrigin) {
+      if (listeners[messageData.type]) listeners[messageData.type](messageData.content);
+    }
+  }
 
-   function disconnect() {
-     connected = false;
-     stopPostingHello();
-     window.removeEventListener('message', messsageListener);
-   }
+  function disconnect() {
+    connected = false;
+    stopPostingHello();
+    window.removeEventListener('message', messsageListener);
+  }
 
   /**
     Initialize communication with the parent frame. This should not be called until the app's custom

--- a/lib/iframe-phone-rpc-endpoint.js
+++ b/lib/iframe-phone-rpc-endpoint.js
@@ -1,90 +1,88 @@
-"use strict";
-
 var ParentEndpoint = require('./parent-endpoint');
 var getIFrameEndpoint = require('./iframe-endpoint');
 
 // Not a real UUID as there's an RFC for that (needed for proper distributed computing).
 // But in this fairly parochial situation, we just need to be fairly sure to avoid repeats.
 function getPseudoUUID() {
-    var chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    var len = chars.length;
-    var ret = [];
+  var chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  var len = chars.length;
+  var ret = [];
 
-    for (var i = 0; i < 10; i++) {
-        ret.push(chars[Math.floor(Math.random() * len)]);
-    }
-    return ret.join('');
+  for (var i = 0; i < 10; i++) {
+    ret.push(chars[Math.floor(Math.random() * len)]);
+  }
+  return ret.join('');
 }
 
 module.exports = function IframePhoneRpcEndpoint(handler, namespace, targetWindow, targetOrigin, phone) {
-    var pendingCallbacks = Object.create({});
+  var pendingCallbacks = Object.create({});
 
-    // if it's a non-null object, rather than a function, 'handler' is really an options object
-    if (handler && typeof handler === 'object') {
-        namespace = handler.namespace;
-        targetWindow = handler.targetWindow;
-        targetOrigin = handler.targetOrigin;
-        phone = handler.phone;
-        handler = handler.handler;
+  // if it's a non-null object, rather than a function, 'handler' is really an options object
+  if (handler && typeof handler === 'object') {
+    namespace = handler.namespace;
+    targetWindow = handler.targetWindow;
+    targetOrigin = handler.targetOrigin;
+    phone = handler.phone;
+    handler = handler.handler;
+  }
+
+  if (!phone) {
+    if (targetWindow === window.parent) {
+      phone = getIFrameEndpoint();
+      phone.initialize();
+    } else {
+      phone = new ParentEndpoint(targetWindow, targetOrigin);
     }
+  }
 
-    if ( ! phone ) {
-        if (targetWindow === window.parent) {
-            phone = getIFrameEndpoint();
-            phone.initialize();
-        } else {
-            phone = new ParentEndpoint(targetWindow, targetOrigin);
-        }
-    }
+  phone.addListener(namespace, function (message) {
+    var callbackObj;
 
-    phone.addListener(namespace, function(message) {
-        var callbackObj;
-
-        if (message.messageType === 'call' && typeof this.handler === 'function') {
-            this.handler.call(undefined, message.value, function(returnValue) {
-                phone.post(namespace, {
-                    messageType: 'returnValue',
-                    uuid: message.uuid,
-                    value: returnValue
-                });
-            });
-        } else if (message.messageType === 'returnValue') {
-            callbackObj = pendingCallbacks[message.uuid];
-
-            if (callbackObj) {
-                window.clearTimeout(callbackObj.timeout);
-                if (callbackObj.callback) {
-                    callbackObj.callback.call(undefined, message.value);
-                }
-                pendingCallbacks[message.uuid] = null;
-            }
-        }
-    }.bind(this));
-
-    function call(message, callback) {
-        var uuid = getPseudoUUID();
-
-        pendingCallbacks[uuid] = {
-            callback: callback,
-            timeout: window.setTimeout(function() {
-                if (callback) {
-                    callback(undefined, new Error("IframePhone timed out waiting for reply"));
-                }
-            }, 2000)
-        };
-
+    if (message.messageType === 'call' && typeof this.handler === 'function') {
+      this.handler.call(undefined, message.value, function (returnValue) {
         phone.post(namespace, {
-            messageType: 'call',
-            uuid: uuid,
-            value: message
+          messageType: 'returnValue',
+          uuid: message.uuid,
+          value: returnValue
         });
-    }
+      });
+    } else if (message.messageType === 'returnValue') {
+      callbackObj = pendingCallbacks[message.uuid];
 
-    function disconnect() {
-        phone.disconnect();
+      if (callbackObj) {
+        window.clearTimeout(callbackObj.timeout);
+        if (callbackObj.callback) {
+          callbackObj.callback.call(undefined, message.value);
+        }
+        pendingCallbacks[message.uuid] = null;
+      }
     }
+  }.bind(this));
 
-    this.handler = handler;
-    this.call = call.bind(this);
-    this.disconnect = disconnect.bind(this);
+  function call(message, callback) {
+    var uuid = getPseudoUUID();
+
+    pendingCallbacks[uuid] = {
+      callback: callback,
+      timeout: window.setTimeout(function () {
+        if (callback) {
+          callback(undefined, new Error("IframePhone timed out waiting for reply"));
+        }
+      }, 2000)
+    };
+
+    phone.post(namespace, {
+      messageType: 'call',
+      uuid: uuid,
+      value: message
+    });
+  }
+
+  function disconnect() {
+    phone.disconnect();
+  }
+
+  this.handler = handler;
+  this.call = call.bind(this);
+  this.disconnect = disconnect.bind(this);
 };

--- a/lib/parent-endpoint.js
+++ b/lib/parent-endpoint.js
@@ -34,7 +34,6 @@ var structuredClone = require('./structured-clone');
 */
 
 module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, afterConnectedCallback) {
-  var selfOrigin = window.location.href.match(/(.*?\/\/.*?)\//)[1];
   var postMessageQueue = [];
   var connected = false;
   var handlers = {};
@@ -143,9 +142,6 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
   //  > Lastly, posting a message to a page at a file: URL currently requires that the targetOrigin argument be "*".
   //  > file:// cannot be used as a security restriction; this restriction may be modified in the future.
   // So, using '*' seems like the only possible solution.
-  if (selfOrigin === 'file://') {
-    selfOrigin = '*';
-  }
   if (targetOrigin === 'file://') {
     targetOrigin = '*';
   }
@@ -157,7 +153,9 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
     // send hello response
     post({
       type: 'hello',
-      origin: selfOrigin
+      // `origin` property isn't used by IframeEndpoint anymore (>= 1.2.0), but it's being sent to be
+      // backward compatible with old IframeEndpoint versions (< v1.2.0).
+      origin: window.location.href.match(/(.*?\/\/.*?)\//)[1]
     });
 
     // give the user a chance to do things now that we are connected

--- a/lib/parent-endpoint.js
+++ b/lib/parent-endpoint.js
@@ -40,7 +40,7 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
   var handlers = {};
   var targetWindowIsIframeElement;
 
-  function getOrigin(iframe) {
+  function getIframeOrigin(iframe) {
     return iframe.src.match(/(.*?\/\/.*?)\//)[1];
   }
 
@@ -59,7 +59,6 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
     if (connected) {
       var tWindow = getTargetWindow();
       // if we are laready connected ... send the message
-      message.origin = selfOrigin;
       // See http://dev.opera.com/articles/view/window-postmessage-messagechannel/#crossdoc
       //     https://github.com/Modernizr/Modernizr/issues/388
       //     http://jsfiddle.net/ryanseddon/uZTgD/2/
@@ -101,7 +100,7 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
 
   function receiveMessage(message) {
     var messageData;
-    if (message.source === getTargetWindow() && message.origin === targetOrigin) {
+    if (message.source === getTargetWindow() && (targetOrigin === '*' || message.origin === targetOrigin)) {
       messageData = message.data;
       if (typeof messageData === 'string') {
         messageData = JSON.parse(messageData);
@@ -134,8 +133,21 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
     // afterConnectionCallback)
     if (!targetOrigin || targetOrigin.constructor === Function) {
       afterConnectedCallback = targetOrigin;
-      targetOrigin = getOrigin(targetWindowOrIframeEl);
+      targetOrigin = getIframeOrigin(targetWindowOrIframeEl);
     }
+  }
+
+  // Handle pages served through file:// protocol. Behaviour varies in different browsers. Safari sets origin
+  // to 'file://' and everything works fine, but Chrome and Safari set message.origin to null.
+  // Also, https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage says:
+  //  > Lastly, posting a message to a page at a file: URL currently requires that the targetOrigin argument be "*".
+  //  > file:// cannot be used as a security restriction; this restriction may be modified in the future.
+  // So, using '*' seems like the only possible solution.
+  if (selfOrigin === 'file://') {
+    selfOrigin = '*';
+  }
+  if (targetOrigin === 'file://') {
+    targetOrigin = '*';
   }
 
   // when we receive 'hello':
@@ -143,7 +155,10 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
     connected = true;
 
     // send hello response
-    post('hello');
+    post({
+      type: 'hello',
+      origin: selfOrigin
+    });
 
     // give the user a chance to do things now that we are connected
     // note that is will happen before any queued messages

--- a/lib/parent-endpoint.js
+++ b/lib/parent-endpoint.js
@@ -151,7 +151,7 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
   }
 
   // when we receive 'hello':
-  addListener('hello', function() {
+  addListener('hello', function () {
     connected = true;
 
     // send hello response
@@ -167,7 +167,7 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
     }
 
     // Now send any messages that have been queued up ...
-    while(postMessageQueue.length > 0) {
+    while (postMessageQueue.length > 0) {
       post(postMessageQueue.shift());
     }
   });

--- a/lib/structured-clone.js
+++ b/lib/structured-clone.js
@@ -10,7 +10,7 @@ var featureSupported = false;
       // internal [[Class]] property of the message being passed through.
       // Safari will pass through DOM nodes as Null iOS safari on the other hand
       // passes it through as DOMWindow, gotcha.
-      window.onmessage = function(e){
+      window.onmessage = function (e) {
         var type = Object.prototype.toString.call(e.data);
         result = (type.indexOf("Null") != -1 || type.indexOf("DOMWindow") != -1) ? 1 : 0;
         featureSupported = {
@@ -19,8 +19,8 @@ var featureSupported = false;
       };
       // Spec states you can't transmit DOM nodes and it will throw an error
       // postMessage implimentations that support cloned data will throw.
-      window.postMessage(document.createElement("a"),"*");
-    } catch(e) {
+      window.postMessage(document.createElement("a"), "*");
+    } catch (e) {
       // BBOS6 throws but doesn't pass through the correct exception
       // so check error message
       result = (e.DATA_CLONE_ERR || e.message == "Cannot post cyclic structures.") ? 1 : 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-phone",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Convenient communication between the parent site and iframe based on window.postMessage()",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
Please look at the first commit only to see clean diff.

The goal of this PR is to handle pages served through file:// protocol. Behaviour varies in different browsers. Safari sets origin to 'file://' and everything works fine, but Chrome and Safari set message.origin to "null".
Also, https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage says:

> Lastly, posting a message to a page at a file: URL currently requires that the targetOrigin argument be "*".
> file:// cannot be used as a security restriction; this restriction may be modified in the future.

So, using `'*'` seems like the only possible solution to handle file:// protocol.
Also, iframe-phone didn't handle `'*'` at all, so I had to add it.
Finally, I did small cleanup and don't send `origin` in message body when it's not necessary (it's necessary only in hello msg sent from parent to iframe).

This change is backward compatible too.