### PR TITLE
Fix check for support of structured clone

### DIFF
--- a/dist/iframe-phone.js
+++ b/dist/iframe-phone.js
@@ -422,24 +422,15 @@ var featureSupported = false;
 
   if (!!window.postMessage) {
     try {
-      // Safari 5.1 will sometimes throw an exception and sometimes won't, lolwut?
-      // When it doesn't we capture the message event and check the
-      // internal [[Class]] property of the message being passed through.
-      // Safari will pass through DOM nodes as Null iOS safari on the other hand
-      // passes it through as DOMWindow, gotcha.
       var handler = function(e){
-        if (typeof featureSupported !== 'object') {
-          var type = Object.prototype.toString.call(e.data);
-          var result = (type.indexOf("Null") !== -1 || type.indexOf("DOMWindow") !== -1) ? 1 : 0;
-          featureSupported = {
-            'structuredClones': result
-          };
-        }
+        // We should not get here at all. Attempting to send a DOM node over
+        // PostMessage should fail whether Structured Clones are supported or
+        // not. In case we do, however, we can at least remove ourselves.
         window.removeEventListener('message', handler);
       };
       window.addEventListener('message', handler);
       // Spec states you can't transmit DOM nodes and it will throw an error
-      // postMessage implimentations that support cloned data will throw.
+      // postMessage implementations that support cloned data will throw.
       window.postMessage(document.createElement("a"), "*");
     } catch (e) {
       // BBOS6 throws but doesn't pass through the correct exception

--- a/dist/iframe-phone.js
+++ b/dist/iframe-phone.js
@@ -415,27 +415,21 @@ module.exports = function ParentEndpoint(targetWindowOrIframeEl, targetOrigin, a
 };
 
 },{"./structured-clone":4}],4:[function(require,module,exports){
-var featureSupported = false;
+var featureSupported = {
+  'structuredClones': 0
+};
 
 (function () {
   var result = 0;
 
   if (!!window.postMessage) {
     try {
-      var handler = function(e){
-        // We should not get here at all. Attempting to send a DOM node over
-        // PostMessage should fail whether Structured Clones are supported or
-        // not. In case we do, however, we can at least remove ourselves.
-        window.removeEventListener('message', handler);
-      };
-      window.addEventListener('message', handler);
       // Spec states you can't transmit DOM nodes and it will throw an error
       // postMessage implementations that support cloned data will throw.
       window.postMessage(document.createElement("a"), "*");
     } catch (e) {
       // BBOS6 throws but doesn't pass through the correct exception
       // so check error message
-      window.removeEventListener('message', handler);
       result = (e.DATA_CLONE_ERR || e.message === "Cannot post cyclic structures.") ? 1 : 0;
       featureSupported = {
         'structuredClones': result

--- a/dist/iframe-phone.js
+++ b/dist/iframe-phone.js
@@ -427,20 +427,25 @@ var featureSupported = false;
       // internal [[Class]] property of the message being passed through.
       // Safari will pass through DOM nodes as Null iOS safari on the other hand
       // passes it through as DOMWindow, gotcha.
-      window.onmessage = function (e) {
-        var type = Object.prototype.toString.call(e.data);
-        result = (type.indexOf("Null") != -1 || type.indexOf("DOMWindow") != -1) ? 1 : 0;
-        featureSupported = {
-          'structuredClones': result
-        };
+      var handler = function(e){
+        if (typeof featureSupported !== 'object') {
+          var type = Object.prototype.toString.call(e.data);
+          var result = (type.indexOf("Null") !== -1 || type.indexOf("DOMWindow") !== -1) ? 1 : 0;
+          featureSupported = {
+            'structuredClones': result
+          };
+        }
+        window.removeEventListener('message', handler);
       };
+      window.addEventListener('message', handler);
       // Spec states you can't transmit DOM nodes and it will throw an error
       // postMessage implimentations that support cloned data will throw.
       window.postMessage(document.createElement("a"), "*");
     } catch (e) {
       // BBOS6 throws but doesn't pass through the correct exception
       // so check error message
-      result = (e.DATA_CLONE_ERR || e.message == "Cannot post cyclic structures.") ? 1 : 0;
+      window.removeEventListener('message', handler);
+      result = (e.DATA_CLONE_ERR || e.message === "Cannot post cyclic structures.") ? 1 : 0;
       featureSupported = {
         'structuredClones': result
       };

--- a/lib/structured-clone.js
+++ b/lib/structured-clone.js
@@ -10,20 +10,25 @@ var featureSupported = false;
       // internal [[Class]] property of the message being passed through.
       // Safari will pass through DOM nodes as Null iOS safari on the other hand
       // passes it through as DOMWindow, gotcha.
-      window.onmessage = function (e) {
-        var type = Object.prototype.toString.call(e.data);
-        result = (type.indexOf("Null") != -1 || type.indexOf("DOMWindow") != -1) ? 1 : 0;
-        featureSupported = {
-          'structuredClones': result
-        };
+      var handler = function(e){
+        if (typeof featureSupported !== 'object') {
+          var type = Object.prototype.toString.call(e.data);
+          var result = (type.indexOf("Null") !== -1 || type.indexOf("DOMWindow") !== -1) ? 1 : 0;
+          featureSupported = {
+            'structuredClones': result
+          };
+        }
+        window.removeEventListener('message', handler);
       };
+      window.addEventListener('message', handler);
       // Spec states you can't transmit DOM nodes and it will throw an error
       // postMessage implimentations that support cloned data will throw.
       window.postMessage(document.createElement("a"), "*");
     } catch (e) {
       // BBOS6 throws but doesn't pass through the correct exception
       // so check error message
-      result = (e.DATA_CLONE_ERR || e.message == "Cannot post cyclic structures.") ? 1 : 0;
+      window.removeEventListener('message', handler);
+      result = (e.DATA_CLONE_ERR || e.message === "Cannot post cyclic structures.") ? 1 : 0;
       featureSupported = {
         'structuredClones': result
       };

--- a/lib/structured-clone.js
+++ b/lib/structured-clone.js
@@ -1,24 +1,18 @@
-var featureSupported = false;
+var featureSupported = {
+  'structuredClones': 0
+};
 
 (function () {
   var result = 0;
 
   if (!!window.postMessage) {
     try {
-      var handler = function(e){
-        // We should not get here at all. Attempting to send a DOM node over
-        // PostMessage should fail whether Structured Clones are supported or
-        // not. In case we do, however, we can at least remove ourselves.
-        window.removeEventListener('message', handler);
-      };
-      window.addEventListener('message', handler);
       // Spec states you can't transmit DOM nodes and it will throw an error
       // postMessage implementations that support cloned data will throw.
       window.postMessage(document.createElement("a"), "*");
     } catch (e) {
       // BBOS6 throws but doesn't pass through the correct exception
       // so check error message
-      window.removeEventListener('message', handler);
       result = (e.DATA_CLONE_ERR || e.message === "Cannot post cyclic structures.") ? 1 : 0;
       featureSupported = {
         'structuredClones': result

--- a/lib/structured-clone.js
+++ b/lib/structured-clone.js
@@ -5,24 +5,15 @@ var featureSupported = false;
 
   if (!!window.postMessage) {
     try {
-      // Safari 5.1 will sometimes throw an exception and sometimes won't, lolwut?
-      // When it doesn't we capture the message event and check the
-      // internal [[Class]] property of the message being passed through.
-      // Safari will pass through DOM nodes as Null iOS safari on the other hand
-      // passes it through as DOMWindow, gotcha.
       var handler = function(e){
-        if (typeof featureSupported !== 'object') {
-          var type = Object.prototype.toString.call(e.data);
-          var result = (type.indexOf("Null") !== -1 || type.indexOf("DOMWindow") !== -1) ? 1 : 0;
-          featureSupported = {
-            'structuredClones': result
-          };
-        }
+        // We should not get here at all. Attempting to send a DOM node over
+        // PostMessage should fail whether Structured Clones are supported or
+        // not. In case we do, however, we can at least remove ourselves.
         window.removeEventListener('message', handler);
       };
       window.addEventListener('message', handler);
       // Spec states you can't transmit DOM nodes and it will throw an error
-      // postMessage implimentations that support cloned data will throw.
+      // postMessage implementations that support cloned data will throw.
       window.postMessage(document.createElement("a"), "*");
     } catch (e) {
       // BBOS6 throws but doesn't pass through the correct exception

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.2.0",
   "description": "Convenient communication between the parent site and iframe based on window.postMessage()",
   "main": "main.js",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "browserify": ">= 2.35 < 3.0"
   },


### PR DESCRIPTION
The structured clone check was initially successful, but failed to remove its handler.
On subsequent activity, the check for a Safari 5.1 defect would
reset the structured clone supported flag.